### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,6 +1,7 @@
 """This file contains the chat schema for the application."""
 
 import re
+import bleach
 from typing import (
     List,
     Literal,
@@ -40,15 +41,14 @@ class Message(BaseModel):
         Raises:
             ValueError: If the content contains disallowed patterns
         """
-        # Check for potentially harmful content
-        if re.search(r"<script.*?>.*?</script>", v, re.IGNORECASE | re.DOTALL):
-            raise ValueError("Content contains potentially harmful script tags")
+        # Sanitize the content to remove potentially harmful HTML
+        sanitized_content = bleach.clean(v, tags=[], attributes={}, styles=[], strip=True)
 
         # Check for null bytes
-        if "\0" in v:
+        if "\0" in sanitized_content:
             raise ValueError("Content contains null bytes")
 
-        return v
+        return sanitized_content
 
 
 class ChatRequest(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "LangGraph FastAPI Template"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "bleach==6.2.0",
     "fastapi>=0.115.12",
     "langchain>=0.3.22",
     "langchain-openai>=0.3.11",


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/fastapi-langgraph-agent-production-ready-template/security/code-scanning/2](https://github.com/venkateshpabbati/fastapi-langgraph-agent-production-ready-template/security/code-scanning/2)

The best way to fix the problem is to use a well-tested HTML sanitization library instead of relying on custom regular expressions. This ensures that all edge cases and variations in HTML tags are properly handled, reducing the risk of security vulnerabilities.

In this case, we will use the `bleach` library, which is a well-known and widely used library for sanitizing HTML content. We will replace the custom regular expression with a call to `bleach.clean` to sanitize the content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
